### PR TITLE
build: use AC_FUNC_STRERROR_R to check the version of strerror_r()

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -24,6 +24,8 @@ m4_ifdef([AM_SILENT_RULES], [AM_SILENT_RULES([yes])])
 AC_CONFIG_SRCDIR([src])
 AC_CONFIG_HEADER([config.h])
 
+AC_DEFINE([_GNU_SOURCE], [], [We want GNU extensions])
+
 AM_PROG_AR
 AC_PROG_CC
 AC_PROG_LIBTOOL
@@ -41,6 +43,7 @@ AC_DEFUN([HEADER_NOT_FOUND_LIB],
 # This is always checked (library needs this)
 AC_HEADER_STDC
 AC_FUNC_MALLOC
+AC_FUNC_STRERROR_R
 AC_CHECK_FUNC([ioctl], [], [FUNC_NOT_FOUND_LIB([ioctl])])
 AC_CHECK_FUNC([asprintf], [], [FUNC_NOT_FOUND_LIB([asprintf])])
 AC_CHECK_FUNC([readdir], [], [FUNC_NOT_FOUND_LIB([readdir])])

--- a/src/lib/Makefile.am
+++ b/src/lib/Makefile.am
@@ -8,7 +8,7 @@
 
 lib_LTLIBRARIES = libgpiod.la
 libgpiod_la_SOURCES = core.c
-libgpiod_la_CFLAGS = -Wall -Wextra -g -D_GNU_SOURCE
+libgpiod_la_CFLAGS = -Wall -Wextra -g
 libgpiod_la_CFLAGS += -fvisibility=hidden -I$(top_srcdir)/include/
 libgpiod_la_CFLAGS += -include $(top_srcdir)/config.h
 libgpiod_la_LDFLAGS = -version-number $(subst .,:,$(PACKAGE_VERSION))

--- a/src/lib/core.c
+++ b/src/lib/core.c
@@ -143,10 +143,25 @@ int gpiod_errno(void)
 	return last_error;
 }
 
+static const char * strerror_r_wrapper(int errnum, char *buf, size_t buflen)
+{
+#ifdef STRERROR_R_CHAR_P
+	return strerror_r(errnum, buf, buflen);
+#else
+	int status;
+
+	status = strerror_r(errnum, buf, buflen);
+	if (status != 0)
+		snprintf(buf, buflen, "error in strerror_r(): %d", status);
+
+	return buf;
+#endif
+}
+
 const char * gpiod_strerror(int errnum)
 {
 	if (errnum < __GPIOD_ERRNO_OFFSET)
-		return strerror_r(errnum, errmsg, sizeof(errmsg));
+		return strerror_r_wrapper(errnum, errmsg, sizeof(errmsg));
 	else if (errnum > __GPIOD_MAX_ERR)
 		return "invalid error number";
 	else

--- a/src/tools/Makefile.am
+++ b/src/tools/Makefile.am
@@ -7,7 +7,7 @@
 #
 
 AM_CFLAGS = -I$(top_srcdir)/include/ -include $(top_srcdir)/config.h
-AM_CFLAGS += -Wall -Wextra -g -D_GNU_SOURCE -L$(top_srcdir)/src/lib
+AM_CFLAGS += -Wall -Wextra -g -L$(top_srcdir)/src/lib
 AM_LDFLAGS = -lgpiod
 DEPENDENCIES = libgpiod.la
 


### PR DESCRIPTION
Hi @tpetazzoni,

please take a look at this version of the fix for the musl incompatibility.