### PR TITLE
core: Fix out-of-tree builds

### DIFF
--- a/src/lib/Makefile.am
+++ b/src/lib/Makefile.am
@@ -10,5 +10,5 @@ lib_LTLIBRARIES = libgpiod.la
 libgpiod_la_SOURCES = core.c
 libgpiod_la_CFLAGS = -Wall -Wextra -g
 libgpiod_la_CFLAGS += -fvisibility=hidden -I$(top_srcdir)/include/
-libgpiod_la_CFLAGS += -include $(top_srcdir)/config.h
+libgpiod_la_CFLAGS += -include $(top_builddir)/config.h
 libgpiod_la_LDFLAGS = -version-number $(subst .,:,$(PACKAGE_VERSION))

--- a/src/tools/Makefile.am
+++ b/src/tools/Makefile.am
@@ -8,18 +8,24 @@
 
 AM_CFLAGS = -I$(top_srcdir)/include/ -include $(top_builddir)/config.h
 AM_CFLAGS += -Wall -Wextra -g
-LDADD = ../lib/libgpiod.la
+
+noinst_LTLIBRARIES = libtools-common.la
+libtools_common_la_SOURCES = \
+	tools-common.c \
+	tools-common.h
+
+LDADD = ../lib/libgpiod.la libtools-common.la
 
 bin_PROGRAMS = gpiodetect gpioinfo gpioget gpioset gpiomon gpiofind
 
-gpiodetect_SOURCES = gpiodetect.c tools-common.c
+gpiodetect_SOURCES = gpiodetect.c
 
-gpioinfo_SOURCES = gpioinfo.c tools-common.c
+gpioinfo_SOURCES = gpioinfo.c
 
-gpioget_SOURCES = gpioget.c tools-common.c
+gpioget_SOURCES = gpioget.c
 
-gpioset_SOURCES = gpioset.c tools-common.c
+gpioset_SOURCES = gpioset.c
 
-gpiomon_SOURCES = gpiomon.c tools-common.c
+gpiomon_SOURCES = gpiomon.c
 
-gpiofind_SOURCES = gpiofind.c tools-common.c
+gpiofind_SOURCES = gpiofind.c

--- a/src/tools/Makefile.am
+++ b/src/tools/Makefile.am
@@ -6,10 +6,9 @@
 # as published by the Free Software Foundation.
 #
 
-AM_CFLAGS = -I$(top_srcdir)/include/ -include $(top_srcdir)/config.h
+AM_CFLAGS = -I$(top_srcdir)/include/ -include $(top_builddir)/config.h
 AM_CFLAGS += -Wall -Wextra -g
-LDADD = -lgpiod -L$(top_srcdir)/src/lib
-DEPENDENCIES = libgpiod.la
+LDADD = ../lib/libgpiod.la
 
 bin_PROGRAMS = gpiodetect gpioinfo gpioget gpioset gpiomon gpiofind
 


### PR DESCRIPTION
When building out of tree, the config.h header file is generated in the
build directory rather than the source directory.

Signed-off-by: Thierry Reding <treding@nvidia.com>