### PR TITLE
cmakify the project - build it with CMake

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,57 @@
+cmake_minimum_required(VERSION 3.8)
+
+project(libgpiod VERSION 1.3)
+
+set(ABI_VERSION 3.0.1)
+set(ABI_SOVERSION 3)
+set(ABI_CXX_VERSION 1.0.0)
+set(ABI_CXX_SOVERSION 1)
+
+# put internal CMake-variable to the cache
+option(BUILD_SHARED_LIBS "Build libmodbus as a shared library" OFF)
+
+# is this still needed in 2019?
+include(CheckIncludeFile)
+check_include_file(arpa/inet.h HAVE_ARPA_INET_H)
+
+include(CheckFunctionExists)
+check_function_exists(accept4 HAVE_ACCEPT4)
+
+check_function_exists(ioctl HAVE_IOCTL)
+check_function_exists(asprintf HAVE_ASPRINTF)
+check_function_exists(scandir HAVE_SCANDIR)
+check_function_exists(alphasort HAVE_ALPHASORT)
+check_function_exists(ppoll HAVE_PPOLL)
+
+check_include_file(getopt.h        HAVE_GETOPT_H)
+check_include_file(dirent.h,       HAVE_DIRENT_H)
+check_include_file(sys/poll.h      HAVE_SYS_POLL_H)
+check_include_file(sys/sysmacros.h HAVE_SYS_SYSMACROS_H)
+check_include_file(linux/gpio.h    HAVE_LINUX_GPIO_H)
+
+include(GNUInstallDirs)
+
+add_subdirectory(src/lib)
+
+option(ENABLE_TOOLS "enable libgpiod command-line tools" OFF)
+if(ENABLE_TOOLS)
+    add_subdirectory(src/tools)
+endif()
+
+option(ENABLE_BINDINGS_CXX "enable C++ bindings" OFF)
+if(ENABLE_BINDINGS_CXX)
+    add_subdirectory(bindings/cxx)
+endif()
+
+option(ENABLE_BINDINGS_PYTHON "enable python3 bindings" OFF)
+if(ENABLE_BINDINGS_PYTHON)
+    add_subdirectory(bindings/python)
+endif()
+
+option(BUILD_TESTS "enable libgpiod tests" OFF)
+if(BUILD_TESTS)
+    enable_testing()
+    add_subdirectory(tests)
+endif()
+
+

--- a/README
+++ b/README
@@ -47,6 +47,42 @@ arguments to it.
 If building from release tarballs, the configure script is already provided and
 there's no need to invoke autogen.sh.
 
+
+BUILDING with CMake
+-------------------
+
+CMakeLists.txt-files have been added in order to build the project with CMake.
+
+This is a standard cmake && make install. It generates exported .cmake-files
+in order to easily import the installed results in other CMake-projects.
+
+Here are some examples how to build this project
+
+To build the project (always out-of-tree):
+
+  mkdir build
+  cd build
+  cmake <path/to/libgpiod>
+  make install
+
+Release build:
+
+  cmake <path/to/libgpiod> -DCMAKE_BUILD_TYPE=Release
+  make
+
+Debug build and build with Ninja
+
+  cmake <path/to/libgpiod> -DCMAKE_BUILD_TYPE=Debug -GNinja
+  make install
+
+Enable tools and C++-binding
+
+  cmake <path/to/libgpiod> \
+        -DENABLE_TOOLS=ON \
+        -DENABLE_BINDINGS_CXX=ON \
+        -DCMAKE_BUILD_TYPE=Debug
+  make
+
 TOOLS
 -----
 
@@ -133,12 +169,22 @@ superuser privileges:
 
     sudo ./tests/gpiod-test
 
+To enable tests with CMake run
+
+    cmake -DENABLE_TESTS
+
+and then
+
+    ctest
+
+
 BINDINGS
 --------
 
 High-level, object-oriented bindings for C++ and python3 are provided. They
 can be enabled by passing --enable-bindings-cxx and --enable-bindings-python
-arguments respectively to configure.
+arguments respectively to configure. (ENABLE_BINDINGS_CXX and
+ENABLE_BINDING_PYTHON with CMake)
 
 C++ bindings require C++11 support and autoconf-archive collection if building
 from git.

--- a/bindings/cxx/CMakeLists.txt
+++ b/bindings/cxx/CMakeLists.txt
@@ -1,0 +1,39 @@
+add_library(gpiodcxx
+    chip.cpp
+    iter.cpp
+    line.cpp
+    line_bulk.cpp)
+
+target_include_directories(gpiodcxx
+    PRIVATE
+        .
+    INTERFACE
+        $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>
+        $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}/gpiod>)
+
+target_compile_options(gpiodcxx
+    PRIVATE
+        -Wall -Wextra
+        -fvisibility=hidden)
+
+target_compile_features(gpiodcxx
+    PUBLIC
+        cxx_std_11)
+
+set_target_properties(gpiodcxx
+    PROPERTIES
+        VERSION ${ABI_CXX_VERSION}
+        SOVERSION ${ABI_CXX_SOVERSION}
+        PUBLIC_HEADER ${CMAKE_CURRENT_SOURCE_DIR}/gpiod.hpp)
+
+target_link_libraries(gpiodcxx
+    PUBLIC
+        gpiod)
+
+install(TARGETS gpiodcxx EXPORT libgpiodCXXConfig
+    LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
+    ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
+    PUBLIC_HEADER DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/gpiod)
+install(EXPORT libgpiodCXXConfig DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake)
+
+add_subdirectory(examples)

--- a/bindings/cxx/examples/CMakeLists.txt
+++ b/bindings/cxx/examples/CMakeLists.txt
@@ -1,0 +1,13 @@
+set(EXAMPLES
+        gpiod_cxx_tests
+        gpiodetectcxx
+        gpiofindcxx
+        gpiogetcxx
+        gpioinfocxx
+        gpiomoncxx
+        gpiosetcxx)
+
+foreach (ex ${EXAMPLES})
+    add_executable(${ex} ${ex}.cpp)
+    target_link_libraries(${ex} gpiodcxx)
+endforeach()

--- a/bindings/python/CMakeLists.txt
+++ b/bindings/python/CMakeLists.txt
@@ -1,0 +1,5 @@
+
+# TODO how to build a python module with CMake
+find_package(Python3 REQUIRED)
+
+# add_library(gpiod-python MODULE gpiodmodule.c)

--- a/src/lib/CMakeLists.txt
+++ b/src/lib/CMakeLists.txt
@@ -1,0 +1,30 @@
+add_library(gpiod core.c ctxless.c helpers.c iter.c misc.c)
+
+target_compile_options(gpiod
+    PRIVATE
+        -Wall -Wextra
+        -fvisibility=hidden)
+    # -include ${PROJECT_BINARY_DIR}/config.h) is this really needed in 2019?
+target_compile_definitions(gpiod
+    PRIVATE
+        -DGPIOD_VERSION_STR="${PROJECT_VERSION}"
+        -D_GNU_SOURCE)
+
+target_include_directories(gpiod
+    PRIVATE
+        ${PROJECT_SOURCE_DIR}/include
+    INTERFACE
+        $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/include>
+        $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}/gpiod>)
+
+set_target_properties(gpiod
+    PROPERTIES
+        VERSION ${ABI_VERSION}
+        SOVERSION ${ABI_SOVERSION}
+        PUBLIC_HEADER ${PROJECT_SOURCE_DIR}/include/gpiod.h)
+
+install(TARGETS gpiod EXPORT libgpiodConfig
+        LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
+        ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
+        PUBLIC_HEADER DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/gpiod)
+install(EXPORT libgpiodConfig DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake)

--- a/src/tools/CMakeLists.txt
+++ b/src/tools/CMakeLists.txt
@@ -1,0 +1,22 @@
+add_library(tools-common STATIC tools-common.c)
+
+target_compile_options(tools-common
+    PUBLIC
+        -Wall -Wextra)
+
+target_compile_definitions(tools-common
+    PUBLIC
+        -D_GNU_SOURCE)
+
+target_link_libraries(tools-common
+    PUBLIC
+        gpiod)
+
+set(TOOLS gpiodetect gpioinfo gpioget gpioset gpiomon gpiofind)
+
+foreach(tool ${TOOLS})
+    add_executable(${tool} ${tool}.c)
+    target_link_libraries(${tool} tools-common)
+endforeach()
+
+install(TARGETS ${TOOLS} RUNTIME DESTINATION bin)


### PR DESCRIPTION
Differences with autotools (for the moment):
- does not use config.h for HAVE_-macros (should it)?
- does not generate .pc-files (but .cmake-ones are)
- Python-module is not built

I don't know what you think about CMake. I find it so much easier for cross-compilation and 
feature activation that I decided to add it for our build. 

Thanks in advance for reviewing ;-) .