### PR TITLE
Add auto-generation of PDF format for documentation.

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -30,6 +30,9 @@ build:
       - pandoc
       - pkg-config
 
+formats:
+   - pdf
+
 sphinx:
    configuration: docs/conf.py
 


### PR DESCRIPTION
Instruct ReadTheDocs to also generate a PDF version of the documentation for offline usage.